### PR TITLE
Colorize GlyphWidget, add BubblesWidget

### DIFF
--- a/dexter_widgets/bubbles.py
+++ b/dexter_widgets/bubbles.py
@@ -1,0 +1,77 @@
+# SPDX-FileCopyrightText: Copyright (c) 2021 Randall Bohn (dexter)
+#
+# SPDX-License-Identifier: MIT
+"""BubblesWidget
+Just for fun."""
+# circup install adafruit_displayio_layout
+# circup install adafruit_display_shapes
+# circup install adafruit_fancyled
+import random
+
+from adafruit_display_shapes.circle import Circle
+import adafruit_fancyled.adafruit_fancyled as fancy
+from adafruit_displayio_layout.widgets.widget import Widget
+
+september = [fancy.CRGB(255, 0, 0), fancy.CRGB(255, 240, 0), fancy.CRGB(128, 255, 0)]
+ice = [
+    fancy.CRGB(255, 255, 255),
+    fancy.CRGB(240, 240, 240),
+    fancy.CRGB(255, 255, 255),
+    fancy.CRGB(128, 255, 255),
+]
+snow = [fancy.CRGB(255, 255, 255), fancy.CRGB(160, 192, 192)]
+tms = [
+    fancy.CRGB(0xD7, 0xB4, 0x54),
+    fancy.CRGB(0x0A, 0x8C, 0x18),
+    fancy.CRGB(0xFF, 0x5F, 0x4C),
+]
+red_blue = [fancy.CRGB(255, 0, 0), fancy.CRGB(0, 0, 255)]
+
+
+class BubblesWidget(Widget):
+    """
+    A widget with n 'bubbles'.
+    Add it to a GridLayout or other layout.
+    Call animate() repeatedly.
+    Bubbles move within the widget.
+    """
+
+    def __init__(self, n, gradient=None, **kwargs):
+        gradient = gradient or snow
+        super().__init__(**kwargs)
+        self.max_bubble_radius = 6
+        for _ in range(n):
+            self.append(
+                Circle(
+                    30 + random.randint(-5, 5),
+                    30 + random.randint(-5, 5),
+                    6,
+                    fill=fancy.palette_lookup(gradient, random.random()).pack(),
+                )
+            )
+
+    def resize(self, new_width: int, new_height: int) -> None:
+        """
+        Sets self._width and self._height.
+        Spread the bubbles across y.
+        """
+
+        super().resize(new_width, new_height)
+        for shape in self:
+            shape.x = random.randrange(0, new_width - self.max_bubble_radius)
+            shape.y = random.randrange(0, new_height)
+
+    def animate(self):
+        """
+        Move the bubbles.
+        Wrap side-to-side or bottom-to-top.
+        """
+        for shape in self:
+            shape.x += random.randint(-1, 1)
+            shape.y += random.randint(0, 2)
+            if shape.x < 0:
+                shape.x = self._width - 1
+            if shape.x > self._width - self.max_bubble_radius:
+                shape.x = 1
+            if shape.y > self._height:
+                shape.y = 0

--- a/dexter_widgets/glyph_widget.py
+++ b/dexter_widgets/glyph_widget.py
@@ -8,6 +8,7 @@ You can get ForkAwesome-42.pcf
 from https://emergent.unpythonic.net/01606790241
 """
 
+import displayio
 from adafruit_bitmap_font.bitmap_font import load_font
 from adafruit_displayio_layout.widgets.widget import Widget
 from adafruit_display_text.label import Label
@@ -23,11 +24,18 @@ class GlyphWidget(Widget):
     """Provides a ForkAwesome glyph as a Widget."""
 
     def __init__(self, glyph: str, **kwargs):
+        self._background_color = None
         super().__init__(**kwargs)
         self.label = Label(FONT, text=glyph)
         self.label.anchor_point = 0.5, 0.5
         self.label.anchored_position = 21, 21
         self.append(self.label)
+        self._background_palette = displayio.Palette(1)
+
+    def _empty(self):
+        """remove all items from this widget"""
+        while len(self) > 0:
+            self.pop()
 
     def resize(self, new_width: int, new_height: int) -> None:
         """Resize the widget to a new width and height.
@@ -39,3 +47,32 @@ class GlyphWidget(Widget):
         :return: None
         """
         self.label.anchored_position = new_width // 2, new_height // 2
+        if self.background_color:
+            self._background_palette[0] = self._background_color
+            self._empty()
+            background_bitmap = displayio.Bitmap(new_width, new_height, 1)
+            self.append(
+                displayio.TileGrid(
+                    background_bitmap, pixel_shader=self._background_palette
+                )
+            )
+            self.append(self.label)
+
+    @property
+    def color(self):
+        """returns foreground color"""
+        return self.label.color
+
+    @color.setter
+    def color(self, new_color):
+        self.label.color = new_color
+
+    @property
+    def background_color(self):
+        """returns the background color"""
+        return self._background_palette[0]
+
+    @background_color.setter
+    def background_color(self, new_color):
+        self._background_color = new_color
+        self._background_palette[0] = new_color

--- a/dexter_widgets/glyph_widget.py
+++ b/dexter_widgets/glyph_widget.py
@@ -24,13 +24,12 @@ class GlyphWidget(Widget):
     """Provides a ForkAwesome glyph as a Widget."""
 
     def __init__(self, glyph: str, **kwargs):
-        self._background_color = None
         super().__init__(**kwargs)
         self.label = Label(FONT, text=glyph)
         self.label.anchor_point = 0.5, 0.5
         self.label.anchored_position = 21, 21
         self.append(self.label)
-        self._background_palette = displayio.Palette(1)
+        self._background_palette = None
 
     def _empty(self):
         """remove all items from this widget"""
@@ -47,8 +46,7 @@ class GlyphWidget(Widget):
         :return: None
         """
         self.label.anchored_position = new_width // 2, new_height // 2
-        if self.background_color:
-            self._background_palette[0] = self._background_color
+        if self._background_palette is not None:
             self._empty()
             background_bitmap = displayio.Bitmap(new_width, new_height, 1)
             self.append(
@@ -70,9 +68,13 @@ class GlyphWidget(Widget):
     @property
     def background_color(self):
         """returns the background color"""
-        return self._background_palette[0]
+        if self._background_palette is not None:
+            return self._background_palette[0]
+        return None
 
     @background_color.setter
     def background_color(self, new_color):
-        self._background_color = new_color
+        """please set an initial background color before you add the widget to a layout"""
+        if self._background_palette is None:
+            self._background_palette = displayio.Palette(1)
         self._background_palette[0] = new_color

--- a/examples/bubbles_demo.py
+++ b/examples/bubbles_demo.py
@@ -1,0 +1,46 @@
+# SPDX-FileCopyrightText: Copyright (c) 2021 Randall Bohn (dexter)
+#
+# SPDX-License-Identifier: Unlicense
+
+# Run me on the 3.5" TFT FeatherWing
+import time
+import board
+import displayio
+
+from adafruit_displayio_layout.layouts.grid_layout import GridLayout
+from bubbles import BubblesWidget, september, snow, ice
+
+if "DISPLAY" in dir(board):
+    display = board.DISPLAY
+else:
+    from adafruit_featherwing import tft_featherwing_35
+
+    displayio.release_displays()
+    wing = tft_featherwing_35.TFTFeatherWing35()
+    display = wing.display
+
+layout = GridLayout(
+    x=0,
+    y=0,
+    width=display.width,
+    height=display.height,
+    grid_size=(3, 1),
+    divider_lines=True,
+)
+display.show(layout)
+
+single = (1, 1)
+september_bubbles = BubblesWidget(12, gradient=september)
+layout.add_content(september_bubbles, (0, 0), single)
+snow_bubbles = BubblesWidget(12, gradient=snow)
+layout.add_content(snow_bubbles, (1, 0), single)
+ice_bubbles = BubblesWidget(12, gradient=ice)
+layout.add_content(ice_bubbles, (2, 0), single)
+
+# from adafruit_bitmapsaver import save_pixels
+# save_pixels("/sd/awesome.bmp", display)
+while True:
+    # time.sleep(0.01)
+    september_bubbles.animate()
+    snow_bubbles.animate()
+    ice_bubbles.animate()

--- a/examples/bubbles_demo.py
+++ b/examples/bubbles_demo.py
@@ -8,7 +8,7 @@ import board
 import displayio
 
 from adafruit_displayio_layout.layouts.grid_layout import GridLayout
-from bubbles import BubblesWidget, september, snow, ice
+from dexter_widgets.bubbles import BubblesWidget, september, snow, ice
 
 if "DISPLAY" in dir(board):
     display = board.DISPLAY

--- a/examples/glyph_widget_simpletest.py
+++ b/examples/glyph_widget_simpletest.py
@@ -12,6 +12,11 @@ from adafruit_featherwing import tft_featherwing_35
 from adafruit_displayio_layout.layouts.grid_layout import GridLayout
 from dexter_widgets.glyph_widget import GlyphWidget
 
+DARK_RED = 0xCC2200
+ORANGE = 0xFF9900
+DARK_GRAY = 0x333333
+GRAY = 0x999999
+
 displayio.release_displays()
 wing = tft_featherwing_35.TFTFeatherWing35()
 display = wing.display
@@ -27,10 +32,19 @@ layout = GridLayout(
 display.show(layout)
 
 single = (1, 1)
-layout.add_content(GlyphWidget("\uF1B0"), (0, 0), single)
+pets = GlyphWidget("\uF1B0")
+pets.color = DARK_GRAY
+pets.background_color = GRAY
+dingir = GlyphWidget("\uF069")
+dingir.color = DARK_RED
+
+layout.add_content(pets, (0, 0), single)
 layout.add_content(GlyphWidget("\uF1EA"), (1, 0), single)
-layout.add_content(GlyphWidget("\uF069"), (2, 0), (1, 2))
+layout.add_content(dingir, (2, 0), (1, 2))
 layout.add_content(GlyphWidget("\uF2CB"), (0, 1), (2, 1))
 
 while True:
-    time.sleep(0.1)
+    time.sleep(0.33)
+    dingir.color = ORANGE
+    time.sleep(0.66)
+    dingir.color = DARK_RED


### PR DESCRIPTION
Adding BubbleWidget.

You can now set the color and background_color on a GlyphWidget.
The background is a bitmap that fills the cell.
You could also set the GlyphWidget label's background color if that is something you want to do.